### PR TITLE
Jcazarin/add dac device driver

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-maivin.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mp-maivin.dts
@@ -68,11 +68,23 @@
 	clock-frequency = <400000>;
 	scl-gpios = <&gpio5 16 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 	sda-gpios = <&gpio5 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+
+	dac@0d {
+		compatible = "ti,dac081c081", "ti,dac5571";
+		reg = <0x0d>;
+		vref-supply = <&csi_3v3>;
+	};
 };
 
 /* Verdin I2C_4_CSI */
 &i2c3 {
 	status = "okay";
+
+	dac@0d {
+		compatible = "ti,dac081c081", "ti,dac5571";
+		reg = <0x0d>;
+		vref-supply = <&csi_3v3>;
+	};
 };
 
 /* Verdin I2C_1 */

--- a/drivers/iio/dac/ti-dac5571.c
+++ b/drivers/iio/dac/ti-dac5571.c
@@ -402,6 +402,7 @@ MODULE_DEVICE_TABLE(of, dac5571_of_id);
 #endif
 
 static const struct i2c_device_id dac5571_id[] = {
+	{"dac081c081", single_8bit},
 	{"dac5571", single_8bit},
 	{"dac6571", single_10bit},
 	{"dac7571", single_12bit},


### PR DESCRIPTION
Adding the dacs to the device tree so they can be controlled using a kernel device driver instead of a user space program (which was being used so far)