### PR TITLE
Fixed the GPIO number used for the m2_3v3 regulator

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-maivin.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mp-maivin.dts
@@ -28,7 +28,7 @@
 		regulator-max-microvolt = <3300000>;
 		regulator-min-microvolt = <3300000>;
 		pinctrl-0 = <&pinctrl_m2_3v3>;
-		gpio = <&gpio3 7 GPIO_ACTIVE_HIGH>;
+		gpio = <&gpio3 1 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 


### PR DESCRIPTION
Signed-off-by: Jose Cazarin <jose@au-zone.com>